### PR TITLE
Plugin config improvements

### DIFF
--- a/api/healthCheck/VertexIncHealthCheck_9_0.xsd
+++ b/api/healthCheck/VertexIncHealthCheck_9_0.xsd
@@ -6,7 +6,7 @@ Copyright (C) Vertex Inc. (2016). All Rights Reserved.--><xsd:schema targetNames
   <xsd:annotation>
     <xsd:appinfo>
       <jaxb:schemaBindings>
-        <jaxb:package name="com.vertexinc.ws.healthcheck.generated"/>
+        <jaxb:package name="org.killbill.billing.plugin.vertex.gen.health"/>
       </jaxb:schemaBindings>
     </xsd:appinfo>
   </xsd:annotation>

--- a/pom.xml
+++ b/pom.xml
@@ -244,7 +244,6 @@
                             <wsdlOptions>
                                 <wsdlOption>
                                     <wsdl>${project.basedir}/api/healthCheck/HealthCheck90_1.wsdl</wsdl>
-                                    <wsdlLocation>classpath:cxf/HealthCheck90_1.wsdl</wsdlLocation>
                                     <extraargs>
                                         <extraarg>-p</extraarg>
                                         <extraarg>org.killbill.billing.plugin.vertex.gen.health</extraarg>

--- a/pom.xml
+++ b/pom.xml
@@ -244,6 +244,7 @@
                             <wsdlOptions>
                                 <wsdlOption>
                                     <wsdl>${project.basedir}/api/healthCheck/HealthCheck90_1.wsdl</wsdl>
+                                    <wsdlLocation>classpath:cxf/HealthCheck90_1.wsdl</wsdlLocation>
                                     <extraargs>
                                         <extraarg>-p</extraarg>
                                         <extraarg>org.killbill.billing.plugin.vertex.gen.health</extraarg>

--- a/src/main/java/org/killbill/billing/plugin/vertex/VertexActivator.java
+++ b/src/main/java/org/killbill/billing/plugin/vertex/VertexActivator.java
@@ -29,9 +29,9 @@ import org.killbill.billing.osgi.libs.killbill.KillbillActivatorBase;
 import org.killbill.billing.plugin.api.notification.PluginConfigurationEventHandler;
 import org.killbill.billing.plugin.core.resources.jooby.PluginApp;
 import org.killbill.billing.plugin.core.resources.jooby.PluginAppBuilder;
+import org.killbill.billing.plugin.vertex.client.VertexHealthcheckClient;
 import org.killbill.billing.plugin.vertex.dao.VertexDao;
 import org.killbill.billing.plugin.vertex.gen.client.TransactionApi;
-import org.killbill.billing.plugin.vertex.gen.health.HealthCheckService;
 import org.killbill.billing.plugin.vertex.health.HealthCheckApiConfigurationHandler;
 import org.killbill.billing.plugin.vertex.health.VertexHealthcheck;
 import org.killbill.billing.plugin.vertex.health.VertexHealthcheckServlet;
@@ -63,8 +63,8 @@ public class VertexActivator extends KillbillActivatorBase {
         final VertexApiClient vertexCalculateTaxApiClient = vertexCalculateTaxApiConfigurationHandler.createConfigurable(configProperties.getProperties());
         vertexCalculateTaxApiConfigurationHandler.setDefaultConfigurable(vertexCalculateTaxApiClient);
 
-        final HealthCheckService healthCheckService = healthCheckApiConfigurationHandler.createConfigurable(configProperties.getProperties());
-        healthCheckApiConfigurationHandler.setDefaultConfigurable(healthCheckService);
+        final VertexHealthcheckClient vertexHealthcheckClient = healthCheckApiConfigurationHandler.createConfigurable(configProperties.getProperties());
+        healthCheckApiConfigurationHandler.setDefaultConfigurable(vertexHealthcheckClient);
 
         // Expose the healthcheck, so other plugins can check on the Vertex status
         final VertexHealthcheck vertexHealthcheck = new VertexHealthcheck(healthCheckApiConfigurationHandler);

--- a/src/main/java/org/killbill/billing/plugin/vertex/VertexActivator.java
+++ b/src/main/java/org/killbill/billing/plugin/vertex/VertexActivator.java
@@ -29,9 +29,10 @@ import org.killbill.billing.osgi.libs.killbill.KillbillActivatorBase;
 import org.killbill.billing.plugin.api.notification.PluginConfigurationEventHandler;
 import org.killbill.billing.plugin.core.resources.jooby.PluginApp;
 import org.killbill.billing.plugin.core.resources.jooby.PluginAppBuilder;
+import org.killbill.billing.plugin.vertex.client.VertexApiClient;
 import org.killbill.billing.plugin.vertex.client.VertexHealthcheckClient;
+import org.killbill.billing.plugin.vertex.client.VertexTransactionApiClient;
 import org.killbill.billing.plugin.vertex.dao.VertexDao;
-import org.killbill.billing.plugin.vertex.gen.client.TransactionApi;
 import org.killbill.billing.plugin.vertex.health.HealthCheckApiConfigurationHandler;
 import org.killbill.billing.plugin.vertex.health.VertexHealthcheck;
 import org.killbill.billing.plugin.vertex.health.VertexHealthcheckServlet;
@@ -57,14 +58,14 @@ public class VertexActivator extends KillbillActivatorBase {
         vertexCalculateTaxApiConfigurationHandler = new VertexCalculateTaxApiConfigurationHandler(PLUGIN_NAME, killbillAPI);
         healthCheckApiConfigurationHandler = new HealthCheckApiConfigurationHandler(PLUGIN_NAME, killbillAPI);
 
-        final TransactionApi vertexTransactionApiClient = vertexTransactionApiConfigurationHandler.createConfigurable(configProperties.getProperties());
+        final VertexTransactionApiClient vertexTransactionApiClient = vertexTransactionApiConfigurationHandler.createConfigurable(configProperties.getProperties());
         vertexTransactionApiConfigurationHandler.setDefaultConfigurable(vertexTransactionApiClient);
 
         final VertexApiClient vertexCalculateTaxApiClient = vertexCalculateTaxApiConfigurationHandler.createConfigurable(configProperties.getProperties());
         vertexCalculateTaxApiConfigurationHandler.setDefaultConfigurable(vertexCalculateTaxApiClient);
 
-        final VertexHealthcheckClient vertexHealthcheckClient = healthCheckApiConfigurationHandler.createConfigurable(configProperties.getProperties());
-        healthCheckApiConfigurationHandler.setDefaultConfigurable(vertexHealthcheckClient);
+        final VertexHealthcheckClient vertexHealthcheckClientImpl = healthCheckApiConfigurationHandler.createConfigurable(configProperties.getProperties());
+        healthCheckApiConfigurationHandler.setDefaultConfigurable(vertexHealthcheckClientImpl);
 
         // Expose the healthcheck, so other plugins can check on the Vertex status
         final VertexHealthcheck vertexHealthcheck = new VertexHealthcheck(healthCheckApiConfigurationHandler);
@@ -95,8 +96,7 @@ public class VertexActivator extends KillbillActivatorBase {
     }
 
     public void registerHandlers() {
-        final PluginConfigurationEventHandler handler = new PluginConfigurationEventHandler(vertexTransactionApiConfigurationHandler,
-                                                                                            vertexCalculateTaxApiConfigurationHandler);
+        final PluginConfigurationEventHandler handler = new PluginConfigurationEventHandler(vertexTransactionApiConfigurationHandler, vertexCalculateTaxApiConfigurationHandler);
         dispatcher.registerEventHandlers(handler);
     }
 

--- a/src/main/java/org/killbill/billing/plugin/vertex/VertexCalculateTaxApiConfigurationHandler.java
+++ b/src/main/java/org/killbill/billing/plugin/vertex/VertexCalculateTaxApiConfigurationHandler.java
@@ -19,8 +19,16 @@ package org.killbill.billing.plugin.vertex;
 
 import java.util.Properties;
 
+import org.jooq.tools.StringUtils;
 import org.killbill.billing.osgi.libs.killbill.OSGIKillbillAPI;
 import org.killbill.billing.plugin.api.notification.PluginTenantConfigurableConfigurationHandler;
+import org.killbill.billing.plugin.vertex.client.NotConfiguredVertexApiClient;
+import org.killbill.billing.plugin.vertex.client.VertexApiClient;
+import org.killbill.billing.plugin.vertex.client.VertexApiClientImpl;
+
+import static org.killbill.billing.plugin.vertex.VertexConfigProperties.VERTEX_OSERIES_CLIENT_ID_PROPERTY;
+import static org.killbill.billing.plugin.vertex.VertexConfigProperties.VERTEX_OSERIES_CLIENT_SECRET_PROPERTY;
+import static org.killbill.billing.plugin.vertex.VertexConfigProperties.VERTEX_OSERIES_URL_PROPERTY;
 
 public class VertexCalculateTaxApiConfigurationHandler extends PluginTenantConfigurableConfigurationHandler<VertexApiClient> {
 
@@ -30,6 +38,14 @@ public class VertexCalculateTaxApiConfigurationHandler extends PluginTenantConfi
 
     @Override
     protected VertexApiClient createConfigurable(final Properties properties) {
-        return new VertexApiClient(properties);
+        final String url = properties.getProperty(VERTEX_OSERIES_URL_PROPERTY);
+        final String clientId = properties.getProperty(VERTEX_OSERIES_CLIENT_ID_PROPERTY);
+        final String clientSecret = properties.getProperty(VERTEX_OSERIES_CLIENT_SECRET_PROPERTY);
+
+        if (StringUtils.isBlank(url) || StringUtils.isBlank(clientId) || StringUtils.isBlank(clientSecret)) {
+            return new NotConfiguredVertexApiClient();
+        }
+
+        return new VertexApiClientImpl(properties);
     }
 }

--- a/src/main/java/org/killbill/billing/plugin/vertex/VertexConfigProperties.java
+++ b/src/main/java/org/killbill/billing/plugin/vertex/VertexConfigProperties.java
@@ -21,26 +21,16 @@ public class VertexConfigProperties {
 
     public static final String PROPERTY_PREFIX = "org.killbill.billing.plugin.vertex.";
 
-    /**
-     * Required parameter
-     */
     public static final String VERTEX_OSERIES_URL_PROPERTY = PROPERTY_PREFIX + "url";
 
-    /**
-     * Required parameters for Vertex tax api
-     */
+    //Tax api credentials
     public static final String VERTEX_OSERIES_CLIENT_ID_PROPERTY = PROPERTY_PREFIX + "clientId";
     public static final String VERTEX_OSERIES_CLIENT_SECRET_PROPERTY = PROPERTY_PREFIX + "clientSecret";
 
-    /**
-     * Required parameters for Vertex healthcheck api
-     */
+    //Healthcheck api credentials
     public static final String VERTEX_OSERIES_USERNAME_PROPERTY = PROPERTY_PREFIX + "username";
     public static final String VERTEX_OSERIES_PASSWORD_PROPERTY = PROPERTY_PREFIX + "password";
 
-    /**
-     * Optional parameters
-     */
     public static final String VERTEX_OSERIES_COMPANY_NAME_PROPERTY = PROPERTY_PREFIX + "companyName";
     public static final String VERTEX_OSERIES_COMPANY_DIVISION_PROPERTY = PROPERTY_PREFIX + "companyDivision";
 }

--- a/src/main/java/org/killbill/billing/plugin/vertex/VertexConfigProperties.java
+++ b/src/main/java/org/killbill/billing/plugin/vertex/VertexConfigProperties.java
@@ -20,13 +20,27 @@ package org.killbill.billing.plugin.vertex;
 public class VertexConfigProperties {
 
     public static final String PROPERTY_PREFIX = "org.killbill.billing.plugin.vertex.";
-    public static final String VERTEX_SKIP = "VERTEX_SKIP";
-    public static final String VERTEX_USERNAME = "VERTEX_USERNAME";
-    public static final String VERTEX_PASSWORD = "VERTEX_PASSWORD";
+
+    /**
+     * Required parameter
+     */
     public static final String VERTEX_OSERIES_URL_PROPERTY = PROPERTY_PREFIX + "url";
+
+    /**
+     * Required parameters for Vertex tax api
+     */
     public static final String VERTEX_OSERIES_CLIENT_ID_PROPERTY = PROPERTY_PREFIX + "clientId";
     public static final String VERTEX_OSERIES_CLIENT_SECRET_PROPERTY = PROPERTY_PREFIX + "clientSecret";
+
+    /**
+     * Required parameters for Vertex healthcheck api
+     */
+    public static final String VERTEX_OSERIES_USERNAME_PROPERTY = PROPERTY_PREFIX + "username";
+    public static final String VERTEX_OSERIES_PASSWORD_PROPERTY = PROPERTY_PREFIX + "password";
+
+    /**
+     * Optional parameters
+     */
     public static final String VERTEX_OSERIES_COMPANY_NAME_PROPERTY = PROPERTY_PREFIX + "companyName";
     public static final String VERTEX_OSERIES_COMPANY_DIVISION_PROPERTY = PROPERTY_PREFIX + "companyDivision";
-    public static final String VERTEX_OAUTH_TOKEN = "VERTEX_OAUTH_TOKEN";
 }

--- a/src/main/java/org/killbill/billing/plugin/vertex/VertexInvoicePluginApi.java
+++ b/src/main/java/org/killbill/billing/plugin/vertex/VertexInvoicePluginApi.java
@@ -46,8 +46,6 @@ import org.killbill.clock.Clock;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
-import static org.killbill.billing.plugin.vertex.VertexConfigProperties.VERTEX_SKIP;
-
 public class VertexInvoicePluginApi extends PluginInvoicePluginApi {
 
     private final VertexTaxCalculator calculator;
@@ -65,11 +63,11 @@ public class VertexInvoicePluginApi extends PluginInvoicePluginApi {
                                                        final boolean dryRun,
                                                        final Iterable<PluginProperty> properties,
                                                        final CallContext context) {
-        final Collection<PluginProperty> pluginProperties = Lists.newArrayList(properties);
-
-        if (PluginProperties.findPluginPropertyValue(VERTEX_SKIP, pluginProperties) != null) {
+        if (PluginProperties.findPluginPropertyValue("VERTEX_SKIP", properties) != null) {
             return ImmutableList.of();
         }
+
+        final Collection<PluginProperty> pluginProperties = Lists.newArrayList(properties);
 
         final Account account = getAccount(invoice.getAccountId(), context);
 

--- a/src/main/java/org/killbill/billing/plugin/vertex/client/NotConfiguredVertexApiClient.java
+++ b/src/main/java/org/killbill/billing/plugin/vertex/client/NotConfiguredVertexApiClient.java
@@ -17,12 +17,5 @@
 
 package org.killbill.billing.plugin.vertex.client;
 
-import org.killbill.billing.plugin.vertex.gen.health.HealthCheckException;
-import org.killbill.billing.plugin.vertex.gen.health.PerformHealthCheckResponseType;
-
-public interface VertexHealthcheckClient {
-
-    default PerformHealthCheckResponseType healthCheck() throws HealthCheckException {
-        throw new IllegalStateException("Vertex plugin is not configured, please upload plugin configuration properties (url, username, password)");
-    }
+public class NotConfiguredVertexApiClient implements VertexApiClient {
 }

--- a/src/main/java/org/killbill/billing/plugin/vertex/client/NotConfiguredVertexHealthcheckClient.java
+++ b/src/main/java/org/killbill/billing/plugin/vertex/client/NotConfiguredVertexHealthcheckClient.java
@@ -17,12 +17,5 @@
 
 package org.killbill.billing.plugin.vertex.client;
 
-import org.killbill.billing.plugin.vertex.gen.health.HealthCheckException;
-import org.killbill.billing.plugin.vertex.gen.health.PerformHealthCheckResponseType;
-
-public interface VertexHealthcheckClient {
-
-    default PerformHealthCheckResponseType healthCheck() throws HealthCheckException {
-        throw new IllegalStateException("Vertex plugin is not configured, please upload plugin configuration properties (url, username, password)");
-    }
+public class NotConfiguredVertexHealthcheckClient implements VertexHealthcheckClient {
 }

--- a/src/main/java/org/killbill/billing/plugin/vertex/client/NotConfiguredVertexTransactionApiClient.java
+++ b/src/main/java/org/killbill/billing/plugin/vertex/client/NotConfiguredVertexTransactionApiClient.java
@@ -17,12 +17,5 @@
 
 package org.killbill.billing.plugin.vertex.client;
 
-import org.killbill.billing.plugin.vertex.gen.health.HealthCheckException;
-import org.killbill.billing.plugin.vertex.gen.health.PerformHealthCheckResponseType;
-
-public interface VertexHealthcheckClient {
-
-    default PerformHealthCheckResponseType healthCheck() throws HealthCheckException {
-        throw new IllegalStateException("Vertex plugin is not configured, please upload plugin configuration properties (url, username, password)");
-    }
+public class NotConfiguredVertexTransactionApiClient implements VertexTransactionApiClient {
 }

--- a/src/main/java/org/killbill/billing/plugin/vertex/client/VertexApiClient.java
+++ b/src/main/java/org/killbill/billing/plugin/vertex/client/VertexApiClient.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020-2023 Equinix, Inc
+ * Copyright 2020-2023 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.plugin.vertex.client;
+
+import org.killbill.billing.plugin.vertex.gen.ApiException;
+import org.killbill.billing.plugin.vertex.gen.client.model.ApiSuccessResponseTransactionResponseType;
+import org.killbill.billing.plugin.vertex.gen.client.model.SaleRequestType;
+
+public interface VertexApiClient {
+    default ApiSuccessResponseTransactionResponseType calculateTaxes(SaleRequestType taxRequest) throws ApiException {
+        throw new IllegalStateException("Vertex plugin is not configured, please upload plugin configuration properties (url, clientId, clientSecret)");
+    }
+    default String getCompanyName() {
+        throw new IllegalStateException("Vertex plugin is not configured, please upload plugin configuration properties (url, clientId, clientSecret)");
+    }
+    default String getCompanyDivision() {
+        throw new IllegalStateException("Vertex plugin is not configured, please upload plugin configuration properties (url, clientId, clientSecret)");
+    }
+}

--- a/src/main/java/org/killbill/billing/plugin/vertex/client/VertexApiClientImpl.java
+++ b/src/main/java/org/killbill/billing/plugin/vertex/client/VertexApiClientImpl.java
@@ -15,7 +15,7 @@
  * under the License.
  */
 
-package org.killbill.billing.plugin.vertex;
+package org.killbill.billing.plugin.vertex.client;
 
 import java.util.Properties;
 
@@ -32,14 +32,14 @@ import static org.killbill.billing.plugin.vertex.VertexConfigProperties.VERTEX_O
 import static org.killbill.billing.plugin.vertex.VertexConfigProperties.VERTEX_OSERIES_COMPANY_NAME_PROPERTY;
 import static org.killbill.billing.plugin.vertex.VertexConfigProperties.VERTEX_OSERIES_URL_PROPERTY;
 
-public class VertexApiClient {
+public class VertexApiClientImpl implements VertexApiClient {
 
     private final OAuthClient oAuthClient;
     private final CalculateTaxApi calculateTaxApi;
     private final String companyName;
     private final String companyDivision;
 
-    public VertexApiClient(final Properties properties) {
+    public VertexApiClientImpl(final Properties properties) {
         final String url = properties.getProperty(VERTEX_OSERIES_URL_PROPERTY);
         final String clientId = properties.getProperty(VERTEX_OSERIES_CLIENT_ID_PROPERTY);
         final String clientSecret = properties.getProperty(VERTEX_OSERIES_CLIENT_SECRET_PROPERTY);
@@ -51,14 +51,17 @@ public class VertexApiClient {
         this.companyDivision = properties.getProperty(VERTEX_OSERIES_COMPANY_DIVISION_PROPERTY);
     }
 
+    @Override
     public String getCompanyName() {
         return companyName;
     }
 
+    @Override
     public String getCompanyDivision() {
         return companyDivision;
     }
 
+    @Override
     public ApiSuccessResponseTransactionResponseType calculateTaxes(SaleRequestType taxRequest) throws ApiException {
         return calculateTaxApi.salePost(taxRequest);
     }

--- a/src/main/java/org/killbill/billing/plugin/vertex/client/VertexHealthcheckClient.java
+++ b/src/main/java/org/killbill/billing/plugin/vertex/client/VertexHealthcheckClient.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020-2023 Equinix, Inc
+ * Copyright 2020-2023 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.plugin.vertex.client;
+
+import org.killbill.billing.plugin.vertex.gen.health.HealthCheckException;
+import org.killbill.billing.plugin.vertex.gen.health.HealthCheckService;
+
+import com.vertexinc.ws.healthcheck.generated.LoginType;
+import com.vertexinc.ws.healthcheck.generated.PerformHealthCheckRequest;
+import com.vertexinc.ws.healthcheck.generated.PerformHealthCheckResponseType;
+
+public class VertexHealthcheckClient {
+
+    private final HealthCheckService healthCheckService;
+    private final PerformHealthCheckRequest healthCheckRequest;
+
+    public VertexHealthcheckClient(final HealthCheckService healthCheckService, final String username, final String password) {
+        this.healthCheckService = healthCheckService;
+        this.healthCheckRequest = buildHealthcheckRequest(username, password);
+    }
+
+    public PerformHealthCheckResponseType healthCheck() throws HealthCheckException {
+        return healthCheckService.getHealthCheckPort().performHealthCheck(healthCheckRequest);
+    }
+
+    private PerformHealthCheckRequest buildHealthcheckRequest(final String username, final String password) {
+        PerformHealthCheckRequest performHealthCheckRequest = new PerformHealthCheckRequest();
+
+        LoginType login = new LoginType();
+        login.setUserName(username);
+        login.setPassword(password);
+        healthCheckRequest.setLogin(login);
+
+        return performHealthCheckRequest;
+    }
+}

--- a/src/main/java/org/killbill/billing/plugin/vertex/client/VertexHealthcheckClient.java
+++ b/src/main/java/org/killbill/billing/plugin/vertex/client/VertexHealthcheckClient.java
@@ -19,10 +19,9 @@ package org.killbill.billing.plugin.vertex.client;
 
 import org.killbill.billing.plugin.vertex.gen.health.HealthCheckException;
 import org.killbill.billing.plugin.vertex.gen.health.HealthCheckService;
-
-import com.vertexinc.ws.healthcheck.generated.LoginType;
-import com.vertexinc.ws.healthcheck.generated.PerformHealthCheckRequest;
-import com.vertexinc.ws.healthcheck.generated.PerformHealthCheckResponseType;
+import org.killbill.billing.plugin.vertex.gen.health.LoginType;
+import org.killbill.billing.plugin.vertex.gen.health.PerformHealthCheckRequest;
+import org.killbill.billing.plugin.vertex.gen.health.PerformHealthCheckResponseType;
 
 public class VertexHealthcheckClient {
 
@@ -39,13 +38,13 @@ public class VertexHealthcheckClient {
     }
 
     private PerformHealthCheckRequest buildHealthcheckRequest(final String username, final String password) {
-        PerformHealthCheckRequest performHealthCheckRequest = new PerformHealthCheckRequest();
+        PerformHealthCheckRequest healthCheckRequest = new PerformHealthCheckRequest();
 
         LoginType login = new LoginType();
         login.setUserName(username);
         login.setPassword(password);
         healthCheckRequest.setLogin(login);
 
-        return performHealthCheckRequest;
+        return healthCheckRequest;
     }
 }

--- a/src/main/java/org/killbill/billing/plugin/vertex/client/VertexHealthcheckClientImpl.java
+++ b/src/main/java/org/killbill/billing/plugin/vertex/client/VertexHealthcheckClientImpl.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020-2023 Equinix, Inc
+ * Copyright 2020-2023 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.plugin.vertex.client;
+
+import org.killbill.billing.plugin.vertex.gen.health.HealthCheckException;
+import org.killbill.billing.plugin.vertex.gen.health.HealthCheckService;
+import org.killbill.billing.plugin.vertex.gen.health.LoginType;
+import org.killbill.billing.plugin.vertex.gen.health.PerformHealthCheckRequest;
+import org.killbill.billing.plugin.vertex.gen.health.PerformHealthCheckResponseType;
+
+public class VertexHealthcheckClientImpl implements VertexHealthcheckClient{
+
+    private final HealthCheckService healthCheckService;
+    private final PerformHealthCheckRequest healthCheckRequest;
+
+    public VertexHealthcheckClientImpl(final HealthCheckService healthCheckService, final String username, final String password) {
+        this.healthCheckService = healthCheckService;
+        this.healthCheckRequest = buildHealthcheckRequest(username, password);
+    }
+
+    public PerformHealthCheckResponseType healthCheck() throws HealthCheckException {
+        return healthCheckService.getHealthCheckPort().performHealthCheck(healthCheckRequest);
+    }
+
+    private PerformHealthCheckRequest buildHealthcheckRequest(final String username, final String password) {
+        PerformHealthCheckRequest healthCheckRequest = new PerformHealthCheckRequest();
+
+        LoginType login = new LoginType();
+        login.setUserName(username);
+        login.setPassword(password);
+        healthCheckRequest.setLogin(login);
+
+        return healthCheckRequest;
+    }
+}

--- a/src/main/java/org/killbill/billing/plugin/vertex/client/VertexTransactionApiClient.java
+++ b/src/main/java/org/killbill/billing/plugin/vertex/client/VertexTransactionApiClient.java
@@ -17,12 +17,11 @@
 
 package org.killbill.billing.plugin.vertex.client;
 
-import org.killbill.billing.plugin.vertex.gen.health.HealthCheckException;
-import org.killbill.billing.plugin.vertex.gen.health.PerformHealthCheckResponseType;
+import org.killbill.billing.plugin.vertex.gen.ApiException;
+import org.killbill.billing.plugin.vertex.gen.client.model.ApiSuccessRemoveTransactionResponseType;
 
-public interface VertexHealthcheckClient {
-
-    default PerformHealthCheckResponseType healthCheck() throws HealthCheckException {
-        throw new IllegalStateException("Vertex plugin is not configured, please upload plugin configuration properties (url, username, password)");
+public interface VertexTransactionApiClient {
+    default ApiSuccessRemoveTransactionResponseType deleteTransaction(String id) throws ApiException {
+        throw new IllegalStateException("Vertex plugin is not configured, please upload plugin configuration properties (url, clientId, clientSecret)");
     }
 }

--- a/src/main/java/org/killbill/billing/plugin/vertex/client/VertexTransactionApiClientImpl.java
+++ b/src/main/java/org/killbill/billing/plugin/vertex/client/VertexTransactionApiClientImpl.java
@@ -17,12 +17,20 @@
 
 package org.killbill.billing.plugin.vertex.client;
 
-import org.killbill.billing.plugin.vertex.gen.health.HealthCheckException;
-import org.killbill.billing.plugin.vertex.gen.health.PerformHealthCheckResponseType;
+import org.killbill.billing.plugin.vertex.gen.ApiException;
+import org.killbill.billing.plugin.vertex.gen.client.TransactionApi;
+import org.killbill.billing.plugin.vertex.gen.client.model.ApiSuccessRemoveTransactionResponseType;
 
-public interface VertexHealthcheckClient {
+public class VertexTransactionApiClientImpl implements VertexTransactionApiClient {
 
-    default PerformHealthCheckResponseType healthCheck() throws HealthCheckException {
-        throw new IllegalStateException("Vertex plugin is not configured, please upload plugin configuration properties (url, username, password)");
+    private final TransactionApi transactionApi;
+
+    public VertexTransactionApiClientImpl(TransactionApi transactionApi) {
+        this.transactionApi = transactionApi;
+    }
+
+    @Override
+    public ApiSuccessRemoveTransactionResponseType deleteTransaction(final String id) throws ApiException {
+        return transactionApi.deleteTransaction(id);
     }
 }

--- a/src/main/java/org/killbill/billing/plugin/vertex/health/HealthCheckApiConfigurationHandler.java
+++ b/src/main/java/org/killbill/billing/plugin/vertex/health/HealthCheckApiConfigurationHandler.java
@@ -21,9 +21,12 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Properties;
 
+import org.jooq.tools.StringUtils;
 import org.killbill.billing.osgi.libs.killbill.OSGIKillbillAPI;
 import org.killbill.billing.plugin.api.notification.PluginTenantConfigurableConfigurationHandler;
+import org.killbill.billing.plugin.vertex.client.NotConfiguredVertexHealthcheckClient;
 import org.killbill.billing.plugin.vertex.client.VertexHealthcheckClient;
+import org.killbill.billing.plugin.vertex.client.VertexHealthcheckClientImpl;
 import org.killbill.billing.plugin.vertex.gen.health.HealthCheckService;
 
 import static org.killbill.billing.plugin.vertex.VertexConfigProperties.VERTEX_OSERIES_PASSWORD_PROPERTY;
@@ -45,6 +48,10 @@ public class HealthCheckApiConfigurationHandler extends PluginTenantConfigurable
         String username = properties.getProperty(VERTEX_OSERIES_USERNAME_PROPERTY);
         String password = properties.getProperty(VERTEX_OSERIES_PASSWORD_PROPERTY);
 
+        if (StringUtils.isBlank(url) || StringUtils.isBlank(username) || StringUtils.isBlank(password)) {
+            return new NotConfiguredVertexHealthcheckClient();
+        }
+
         HealthCheckService healthCheckService;
         try {
             healthCheckService = new HealthCheckService(new URL(url + HEALTHCHECK_PATH));
@@ -52,6 +59,6 @@ public class HealthCheckApiConfigurationHandler extends PluginTenantConfigurable
             throw new IllegalStateException(e);
         }
 
-        return new VertexHealthcheckClient(healthCheckService, username, password);
+        return new VertexHealthcheckClientImpl(healthCheckService, username, password);
     }
 }

--- a/src/main/java/org/killbill/billing/plugin/vertex/health/HealthCheckApiConfigurationHandler.java
+++ b/src/main/java/org/killbill/billing/plugin/vertex/health/HealthCheckApiConfigurationHandler.java
@@ -32,7 +32,7 @@ import static org.killbill.billing.plugin.vertex.VertexConfigProperties.VERTEX_O
 
 public class HealthCheckApiConfigurationHandler extends PluginTenantConfigurableConfigurationHandler<VertexHealthcheckClient> {
 
-    private final String HEALTHCHECK_PATH = "/vertex-ws/adminservices/HealthCheck90";
+    private static final String HEALTHCHECK_PATH = "/vertex-ws/adminservices/HealthCheck90";
 
     public HealthCheckApiConfigurationHandler(final String pluginName,
                                               final OSGIKillbillAPI osgiKillbillAPI) {

--- a/src/main/java/org/killbill/billing/plugin/vertex/health/VertexHealthcheck.java
+++ b/src/main/java/org/killbill/billing/plugin/vertex/health/VertexHealthcheck.java
@@ -23,11 +23,10 @@ import javax.annotation.Nullable;
 
 import org.killbill.billing.osgi.api.Healthcheck;
 import org.killbill.billing.plugin.vertex.client.VertexHealthcheckClient;
+import org.killbill.billing.plugin.vertex.gen.health.PerformHealthCheckResponseType;
 import org.killbill.billing.tenant.api.Tenant;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.vertexinc.ws.healthcheck.generated.PerformHealthCheckResponseType;
 
 public class VertexHealthcheck implements Healthcheck {
 

--- a/src/main/java/org/killbill/billing/plugin/vertex/health/VertexHealthcheck.java
+++ b/src/main/java/org/killbill/billing/plugin/vertex/health/VertexHealthcheck.java
@@ -45,10 +45,10 @@ public class VertexHealthcheck implements Healthcheck {
             return HealthStatus.healthy("Vertex OK (unauthenticated)");
         } else {
             // Specifying the tenant lets you also validate the tenant configuration
-            final VertexHealthcheckClient vertexHealthcheckClient = healthCheckApiConfigurationHandler.getConfigurable(tenant.getId());
+            final VertexHealthcheckClient vertexHealthcheckClientImpl = healthCheckApiConfigurationHandler.getConfigurable(tenant.getId());
 
             try {
-                PerformHealthCheckResponseType healthCheckResponse = vertexHealthcheckClient.healthCheck();
+                PerformHealthCheckResponseType healthCheckResponse = vertexHealthcheckClientImpl.healthCheck();
 
                 boolean healthy = "OK".equals(healthCheckResponse.getCalcEngine());
                 return healthy ? HealthStatus.healthy("Vertex CalcEngine status: OK") : HealthStatus.unHealthy("Vertex CalcEngine status: " + healthCheckResponse.getCalcEngine());

--- a/src/main/java/org/killbill/billing/plugin/vertex/health/VertexHealthcheck.java
+++ b/src/main/java/org/killbill/billing/plugin/vertex/health/VertexHealthcheck.java
@@ -22,13 +22,11 @@ import java.util.Map;
 import javax.annotation.Nullable;
 
 import org.killbill.billing.osgi.api.Healthcheck;
-import org.killbill.billing.plugin.vertex.gen.health.HealthCheckService;
+import org.killbill.billing.plugin.vertex.client.VertexHealthcheckClient;
 import org.killbill.billing.tenant.api.Tenant;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.vertexinc.ws.healthcheck.generated.LoginType;
-import com.vertexinc.ws.healthcheck.generated.PerformHealthCheckRequest;
 import com.vertexinc.ws.healthcheck.generated.PerformHealthCheckResponseType;
 
 public class VertexHealthcheck implements Healthcheck {
@@ -48,14 +46,11 @@ public class VertexHealthcheck implements Healthcheck {
             return HealthStatus.healthy("Vertex OK (unauthenticated)");
         } else {
             // Specifying the tenant lets you also validate the tenant configuration
-            final HealthCheckService healthCheckService = healthCheckApiConfigurationHandler.getConfigurable(tenant.getId());
+            final VertexHealthcheckClient vertexHealthcheckClient = healthCheckApiConfigurationHandler.getConfigurable(tenant.getId());
+
             try {
-                PerformHealthCheckRequest healthCheckRequest = new PerformHealthCheckRequest();
-                LoginType login = new LoginType();
-                login.setUserName(tenant.getApiKey());//fixme is it OK to set username/password
-                login.setPassword(tenant.getApiSecret());
-                healthCheckRequest.setLogin(login);
-                PerformHealthCheckResponseType healthCheckResponse = healthCheckService.getHealthCheckPort().performHealthCheck(healthCheckRequest);
+                PerformHealthCheckResponseType healthCheckResponse = vertexHealthcheckClient.healthCheck();
+
                 boolean healthy = "OK".equals(healthCheckResponse.getCalcEngine());
                 return healthy ? HealthStatus.healthy("Vertex CalcEngine status: OK") : HealthStatus.unHealthy("Vertex CalcEngine status: " + healthCheckResponse.getCalcEngine());
             } catch (Exception e) {

--- a/src/test/java/org/killbill/billing/plugin/vertex/base/VertexRemoteTestBase.java
+++ b/src/test/java/org/killbill/billing/plugin/vertex/base/VertexRemoteTestBase.java
@@ -22,7 +22,7 @@ import java.util.Properties;
 
 import org.killbill.billing.plugin.TestUtils;
 import org.killbill.billing.plugin.vertex.EmbeddedDbHelper;
-import org.killbill.billing.plugin.vertex.VertexApiClient;
+import org.killbill.billing.plugin.vertex.client.VertexApiClientImpl;
 import org.killbill.billing.plugin.vertex.dao.VertexDao;
 import org.killbill.billing.plugin.vertex.gen.ApiClient;
 import org.killbill.billing.plugin.vertex.oauth.OAuthClient;
@@ -35,8 +35,6 @@ import static org.killbill.billing.plugin.vertex.VertexConfigProperties.VERTEX_O
 import static org.killbill.billing.plugin.vertex.VertexConfigProperties.VERTEX_OSERIES_COMPANY_DIVISION_PROPERTY;
 import static org.killbill.billing.plugin.vertex.VertexConfigProperties.VERTEX_OSERIES_COMPANY_NAME_PROPERTY;
 import static org.killbill.billing.plugin.vertex.VertexConfigProperties.VERTEX_OSERIES_URL_PROPERTY;
-import static org.killbill.billing.plugin.vertex.VertexConfigProperties.VERTEX_PASSWORD;
-import static org.killbill.billing.plugin.vertex.VertexConfigProperties.VERTEX_USERNAME;
 
 public abstract class VertexRemoteTestBase {
 
@@ -45,7 +43,7 @@ public abstract class VertexRemoteTestBase {
     private static final String VERTEX_PROPERTIES = "vertex.properties";
     protected Properties properties;
 
-    protected VertexApiClient vertexApiClient;
+    protected VertexApiClientImpl vertexApiClient;
     protected VertexDao dao;
 
     protected String url;
@@ -80,9 +78,6 @@ public abstract class VertexRemoteTestBase {
 
             properties.put(VERTEX_OSERIES_COMPANY_NAME_PROPERTY, System.getenv("VERTEX_COMPANY_NAME"));
             properties.put(VERTEX_OSERIES_COMPANY_DIVISION_PROPERTY, System.getenv("VERTEX_COMPANY_DIVISION"));
-
-            properties.put(VERTEX_USERNAME, System.getenv(VERTEX_USERNAME));
-            properties.put(VERTEX_PASSWORD, System.getenv(VERTEX_PASSWORD));
         }
 
         this.url = properties.getProperty(VERTEX_OSERIES_URL_PROPERTY);
@@ -92,8 +87,6 @@ public abstract class VertexRemoteTestBase {
         //fixme: do we need this properties duplication?
         this.companyName = properties.getProperty(VERTEX_OSERIES_COMPANY_NAME_PROPERTY);
         this.companyDivision = properties.getProperty(VERTEX_OSERIES_COMPANY_DIVISION_PROPERTY);
-        this.username = properties.getProperty(VERTEX_USERNAME);
-        this.password = properties.getProperty(VERTEX_PASSWORD);
 
         this.properties = properties;
 
@@ -113,7 +106,7 @@ public abstract class VertexRemoteTestBase {
         String token = oAuthClient.getToken(url, clientId, clientSecret).getAccessToken();
         apiClient.setAccessToken(token);
 
-        this.vertexApiClient = new VertexApiClient(properties);
+        this.vertexApiClient = new VertexApiClientImpl(properties);
     }
 
 }

--- a/src/test/java/org/killbill/billing/plugin/vertex/health/VertexHealthCheckTest.java
+++ b/src/test/java/org/killbill/billing/plugin/vertex/health/VertexHealthCheckTest.java
@@ -20,7 +20,6 @@ package org.killbill.billing.plugin.vertex.health;
 import org.killbill.billing.osgi.api.Healthcheck.HealthStatus;
 import org.killbill.billing.plugin.vertex.base.VertexRemoteTestBase;
 import org.killbill.billing.plugin.vertex.client.VertexHealthcheckClient;
-import org.killbill.billing.plugin.vertex.gen.health.HealthCheckService;
 import org.killbill.billing.tenant.api.Tenant;
 import org.killbill.billing.tenant.api.boilerplate.TenantImp;
 import org.testng.Assert;

--- a/src/test/java/org/killbill/billing/plugin/vertex/health/VertexHealthCheckTest.java
+++ b/src/test/java/org/killbill/billing/plugin/vertex/health/VertexHealthCheckTest.java
@@ -19,6 +19,7 @@ package org.killbill.billing.plugin.vertex.health;
 
 import org.killbill.billing.osgi.api.Healthcheck.HealthStatus;
 import org.killbill.billing.plugin.vertex.base.VertexRemoteTestBase;
+import org.killbill.billing.plugin.vertex.client.VertexHealthcheckClient;
 import org.killbill.billing.plugin.vertex.gen.health.HealthCheckService;
 import org.killbill.billing.tenant.api.Tenant;
 import org.killbill.billing.tenant.api.boilerplate.TenantImp;
@@ -30,12 +31,12 @@ public class VertexHealthCheckTest extends VertexRemoteTestBase {
     @Test
     public void test() {
         HealthCheckApiConfigurationHandler handler = new HealthCheckApiConfigurationHandler(null, null);
-        HealthCheckService healthCheckService = handler.createConfigurable(properties);
-        handler.setDefaultConfigurable(healthCheckService);
+        VertexHealthcheckClient vertexHealthcheckClient = handler.createConfigurable(properties);
+        handler.setDefaultConfigurable(vertexHealthcheckClient);
         VertexHealthcheck vertexHealthcheck = new VertexHealthcheck(handler);
 
         TenantImp.Builder tenantBuilder = new TenantImp.Builder<>();
-        Tenant tenant = tenantBuilder.withApiKey(username).withApiSecret(password).build();
+        Tenant tenant = tenantBuilder.withApiKey("anyApiKey").withApiSecret("anyApiSecret").build();
         HealthStatus healthStatus = vertexHealthcheck.getHealthStatus(tenant, null);
         Assert.assertEquals(healthStatus.getDetails().get("message"), "Vertex CalcEngine status: OK");
     }

--- a/src/test/java/org/killbill/billing/plugin/vertex/health/VertexHealthCheckTest.java
+++ b/src/test/java/org/killbill/billing/plugin/vertex/health/VertexHealthCheckTest.java
@@ -30,8 +30,8 @@ public class VertexHealthCheckTest extends VertexRemoteTestBase {
     @Test
     public void test() {
         HealthCheckApiConfigurationHandler handler = new HealthCheckApiConfigurationHandler(null, null);
-        VertexHealthcheckClient vertexHealthcheckClient = handler.createConfigurable(properties);
-        handler.setDefaultConfigurable(vertexHealthcheckClient);
+        VertexHealthcheckClient vertexHealthcheckClientImpl = handler.createConfigurable(properties);
+        handler.setDefaultConfigurable(vertexHealthcheckClientImpl);
         VertexHealthcheck vertexHealthcheck = new VertexHealthcheck(handler);
 
         TenantImp.Builder tenantBuilder = new TenantImp.Builder<>();


### PR DESCRIPTION
Plugin is deployable without configured api clients which make it possible to run it and the make a call uploadPluginConfig/killbill-vertex with the properties to use to activate api clients.

tested with billing-it(revision https://github.com/packethost/billing-it/pull/238): go test -run  TestKillbillSuite/TestInvoiceTaxes_TX.