### PR TITLE
Remove JDK 17 from build matrix as it's not supported by killbill-oss-parent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,5 +9,6 @@ jobs:
     uses: killbill/gh-actions-shared/.github/workflows/ci.yml@main
     with:
       test-profile-matrix: '[ "travis", "integration-mysql", "integration-postgresql" ]'
+      jdk-matrix: '[ "8", "11" ]'
     secrets:
       extra-env: '{ "VERTEX_URL": "${{ secrets.VERTEX_URL }}", "VERTEX_CLIENT_ID": "${{ secrets.VERTEX_CLIENT_ID }}", "VERTEX_CLIENT_SECRET": "${{ secrets.VERTEX_CLIENT_SECRET }}", "VERTEX_COMPANY_NAME": "${{ secrets.VERTEX_COMPANY_NAME }}", "VERTEX_COMPANY_DIVISION": "${{ secrets.VERTEX_COMPANY_DIVISION }}"}'

--- a/pom.xml
+++ b/pom.xml
@@ -41,8 +41,6 @@
     <properties>
         <check.spotbugs-exclude-filter-file>spotbugs-exclude.xml</check.spotbugs-exclude-filter-file>
         <jooq.version>3.14.15</jooq.version>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
         <osgi.private>org.killbill.billing.plugin.vertex.*</osgi.private>
     </properties>
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,8 @@
     <properties>
         <check.spotbugs-exclude-filter-file>spotbugs-exclude.xml</check.spotbugs-exclude-filter-file>
         <jooq.version>3.14.15</jooq.version>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
         <osgi.private>org.killbill.billing.plugin.vertex.*</osgi.private>
     </properties>
     <dependencies>


### PR DESCRIPTION
Current 0.1.y version of plugin is compatible with kill-bill version 0.22.z and based on version 0.144.85 of killbill-oss-parent.

- According to git history Java 11 started to be supported only from [killbill-oss-parent-0.144.58](https://github.com/killbill/killbill-oss-parent/releases/tag/killbill-oss-parent-0.144.58)/. Article about Java 11 support: https://killbill.io/blog/kill-bill-release-0-24-includes-support-for-java-11/
- Article about Java 17 support: https://killbill.io/blog/an-upgraded-kill-bill-tech-stack/

Hence removing Java 17 from CI build matrix.

Note:
manifold-preprocessor has been removed from maven-compiler configuration in later version of killbill-oss-parent (see the difference below)

[0.144.85](https://github.com/killbill/killbill-oss-parent/releases/tag/killbill-oss-parent-0.144.85):
```
<plugin>
                    <groupId>org.apache.maven.plugins</groupId>
                    <artifactId>maven-compiler-plugin</artifactId>
                    <version>3.8.1</version>
                    <configuration>
                        <!-- See profiles section for <release> configuration -->
                        <source>${project.build.targetJdk}</source>
                        <target>${project.build.targetJdk}</target>
                        <encoding>${project.build.sourceEncoding}</encoding>
                        <maxmem>${build.jvmsize}</maxmem>
                        <failOnWarning>${compiler.fail-warnings}</failOnWarning>
                        <showDeprecation>true</showDeprecation>
                        <showWarnings>true</showWarnings>
                        <fork>true</fork>
                        <parameters>true</parameters>
                        <compilerArgs>
                            <!-- Configure manifold plugin -->
                            <!-- Disabled as it caused issues compiling in IntelliJ with Java11
                                 e.g Class XXX is public, should be declared in a file XXX.java
                            <arg>-Xplugin:Manifold</arg>
                            -->
                            <!-- Allow access to internal packages -->
                            <arg>-XDignore.symbol.file</arg>
                        </compilerArgs>
                        <!-- Add the processor path for the plugin -->
                        <annotationProcessorPaths>
                            <path>
                                <groupId>systems.manifold</groupId>
                                <artifactId>manifold-preprocessor</artifactId>
                                <version>2021.1.11</version>
                            </path>
                        </annotationProcessorPaths>
                    </configuration>
                </plugin>
```
[0.146.0](https://github.com/killbill/killbill-oss-parent/releases/tag/killbill-oss-parent-0.146.0)
```
 <plugin>
                    <groupId>org.apache.maven.plugins</groupId>
                    <artifactId>maven-compiler-plugin</artifactId>
                    <version>3.10.1</version>
                    <configuration>
                        <!-- See profiles section for <release> configuration -->
                        <source>${project.build.targetJdk}</source>
                        <target>${project.build.targetJdk}</target>
                        <release>${project.build.targetJdk}</release>
                        <encoding>${project.build.sourceEncoding}</encoding>
                        <maxmem>${build.jvmsize}</maxmem>
                        <failOnWarning>${compiler.fail-warnings}</failOnWarning>
                        <showDeprecation>true</showDeprecation>
                        <showWarnings>true</showWarnings>
                        <fork>true</fork>
                        <parameters>true</parameters>
                        <compilerArgs>
                            <!-- Allow access to internal packages -->
                            <arg>-XDignore.symbol.file</arg>
                        </compilerArgs>
                    </configuration>
                </plugin>
```