### PR TITLE
Fix Vertex OpenAPI specification to specify UTF-8 charset on every api operation

### DIFF
--- a/src/main/resources/openapi/tax-calc-api-v2.json
+++ b/src/main/resources/openapi/tax-calc-api-v2.json
@@ -49,7 +49,7 @@
         "operationId": "salePost",
         "requestBody": {
           "content": {
-            "application/json": {
+            "application/json; charset=UTF-8": {
               "schema": {
                 "$ref": "#/components/schemas/SaleRequestType"
               }
@@ -95,7 +95,7 @@
         "operationId": "purchasePost",
         "requestBody": {
           "content": {
-            "application/json": {
+            "application/json; charset=UTF-8": {
               "schema": {
                 "$ref": "#/components/schemas/PurchaseRequestType"
               }
@@ -143,7 +143,7 @@
         "operationId": "ownerPost",
         "requestBody": {
           "content": {
-            "application/json": {
+            "application/json; charset=UTF-8": {
               "schema": {
                 "$ref": "#/components/schemas/OwnerRequestType"
               }
@@ -250,7 +250,7 @@
         "operationId": "reversalPost",
         "requestBody": {
           "content": {
-            "application/json": {
+            "application/json; charset=UTF-8": {
               "schema": {
                 "$ref": "#/components/schemas/ReversalRequestType"
               }
@@ -343,7 +343,7 @@
         "operationId": "addressLookupPost",
         "requestBody": {
           "content": {
-            "application/json": {
+            "application/json; charset=UTF-8": {
               "schema": {
                 "$ref": "#/components/schemas/AddressLookupRequestType"
               }
@@ -388,7 +388,7 @@
         "operationId": "coordinatesLookupPost",
         "requestBody": {
           "content": {
-            "application/json": {
+            "application/json; charset=UTF-8": {
               "schema": {
                 "$ref": "#/components/schemas/CoordinatesLookupRequestType"
               }
@@ -433,7 +433,7 @@
         "operationId": "taxareaidLookupPost",
         "requestBody": {
           "content": {
-            "application/json": {
+            "application/json; charset=UTF-8": {
               "schema": {
                 "$ref": "#/components/schemas/TaxAreaIdLookupRequestType"
               }
@@ -478,7 +478,7 @@
         "operationId": "externalJurisdictionLookupPost",
         "requestBody": {
           "content": {
-            "application/json": {
+            "application/json; charset=UTF-8": {
               "schema": {
                 "$ref": "#/components/schemas/ExternalJurisdictionLookupRequestType"
               }
@@ -523,7 +523,7 @@
         "operationId": "findTaxareasLookupPost",
         "requestBody": {
           "content": {
-            "application/json": {
+            "application/json; charset=UTF-8": {
               "schema": {
                 "$ref": "#/components/schemas/FindTaxAreasRequestArray"
               }

--- a/src/test/java/org/killbill/billing/plugin/vertex/VertexTaxCalculatorITest.java
+++ b/src/test/java/org/killbill/billing/plugin/vertex/VertexTaxCalculatorITest.java
@@ -61,7 +61,7 @@ public class VertexTaxCalculatorITest extends VertexRemoteTestBase {
     public void setUp() throws Exception {
         account = TestUtils.buildAccount(Currency.USD, "45 Fremont Street", null, "San Francisco", "CA", "94105", "US");
         account2 = TestUtils.buildAccount(Currency.USD, "118 N Clark St Ste 100", null, "San Francisco", "CA", "94105", "US");
-        account3 = TestUtils.buildAccount(Currency.USD, "118 N Clark St Ste 100", null, "Chicago", "IL", "60602", "US");
+        account3 = TestUtils.buildAccount(Currency.USD, "118 N Clark St Ste 100" + 'Ä', null, "Chicago", "IL", "60602", "US");
 
         osgiKillbillAPI = TestUtils.buildOSGIKillbillAPI(account);
         Mockito.when(osgiKillbillAPI.getInvoiceUserApi()).thenReturn(Mockito.mock(InvoiceUserApi.class));


### PR DESCRIPTION
Addresses https://packet.atlassian.net/browse/ENG-21930.

Needed as currently `ISO-8859-1` is used by default in api client generated by `apache-httpclient`.
More info [https://github.com/OpenAPITools/openapi-generator/issues/12797](https://github.com/OpenAPITools/openapi-generator/issues/12797)

Testing:
- Tested by adding `UTF-8` char in on of the addresses in `VertexTaxCalculatorITest`.
- Confirmed locally issue is not reproduced after applying the fix.
- `mvn clean install -Pintegration-postgresql` passed locally with hardcoded old token

Note: Integration tests are failing because of the issue with Vertex expired account: `Service account expired`
