### PR TITLE
Fix Vertex OpenAPI specification to specify UTF-8 charset on every api operation

### DIFF
--- a/src/main/resources/openapi/tax-calc-api-v2.json
+++ b/src/main/resources/openapi/tax-calc-api-v2.json
@@ -49,7 +49,7 @@
         "operationId": "salePost",
         "requestBody": {
           "content": {
-            "application/json": {
+            "application/json; charset=UTF-8": {
               "schema": {
                 "$ref": "#/components/schemas/SaleRequestType"
               }
@@ -95,7 +95,7 @@
         "operationId": "purchasePost",
         "requestBody": {
           "content": {
-            "application/json": {
+            "application/json; charset=UTF-8": {
               "schema": {
                 "$ref": "#/components/schemas/PurchaseRequestType"
               }
@@ -143,7 +143,7 @@
         "operationId": "ownerPost",
         "requestBody": {
           "content": {
-            "application/json": {
+            "application/json; charset=UTF-8": {
               "schema": {
                 "$ref": "#/components/schemas/OwnerRequestType"
               }
@@ -250,7 +250,7 @@
         "operationId": "reversalPost",
         "requestBody": {
           "content": {
-            "application/json": {
+            "application/json; charset=UTF-8": {
               "schema": {
                 "$ref": "#/components/schemas/ReversalRequestType"
               }
@@ -343,7 +343,7 @@
         "operationId": "addressLookupPost",
         "requestBody": {
           "content": {
-            "application/json": {
+            "application/json; charset=UTF-8": {
               "schema": {
                 "$ref": "#/components/schemas/AddressLookupRequestType"
               }
@@ -388,7 +388,7 @@
         "operationId": "coordinatesLookupPost",
         "requestBody": {
           "content": {
-            "application/json": {
+            "application/json; charset=UTF-8": {
               "schema": {
                 "$ref": "#/components/schemas/CoordinatesLookupRequestType"
               }
@@ -433,7 +433,7 @@
         "operationId": "taxareaidLookupPost",
         "requestBody": {
           "content": {
-            "application/json": {
+            "application/json; charset=UTF-8": {
               "schema": {
                 "$ref": "#/components/schemas/TaxAreaIdLookupRequestType"
               }
@@ -478,7 +478,7 @@
         "operationId": "externalJurisdictionLookupPost",
         "requestBody": {
           "content": {
-            "application/json": {
+            "application/json; charset=UTF-8": {
               "schema": {
                 "$ref": "#/components/schemas/ExternalJurisdictionLookupRequestType"
               }
@@ -523,7 +523,7 @@
         "operationId": "findTaxareasLookupPost",
         "requestBody": {
           "content": {
-            "application/json": {
+            "application/json; charset=UTF-8": {
               "schema": {
                 "$ref": "#/components/schemas/FindTaxAreasRequestArray"
               }

--- a/src/test/java/org/killbill/billing/plugin/vertex/VertexTaxCalculatorITest.java
+++ b/src/test/java/org/killbill/billing/plugin/vertex/VertexTaxCalculatorITest.java
@@ -56,6 +56,7 @@ public class VertexTaxCalculatorITest extends VertexRemoteTestBase {
     private Account account2;
     private Account account3;
     private OSGIKillbillAPI osgiKillbillAPI;
+    private VertexTaxCalculator calculator;
 
     @BeforeMethod(groups = "integration")
     public void setUp() throws Exception {
@@ -65,41 +66,56 @@ public class VertexTaxCalculatorITest extends VertexRemoteTestBase {
 
         osgiKillbillAPI = TestUtils.buildOSGIKillbillAPI(account);
         Mockito.when(osgiKillbillAPI.getInvoiceUserApi()).thenReturn(Mockito.mock(InvoiceUserApi.class));
+
+        final VertexApiConfigurationHandler vertexApiConfigurationHandler = new VertexApiConfigurationHandler(VertexActivator.PLUGIN_NAME, osgiKillbillAPI);
+        vertexApiConfigurationHandler.setDefaultConfigurable(vertexApiClient);
+
+        calculator = new VertexTaxCalculator(vertexApiConfigurationHandler, dao, clock, osgiKillbillAPI);
     }
 
     @Test(groups = "integration")
     public void testVertexTaxCalculator() throws Exception {
-        final VertexApiConfigurationHandler vertexApiConfigurationHandler = new VertexApiConfigurationHandler(VertexActivator.PLUGIN_NAME, osgiKillbillAPI);
-        vertexApiConfigurationHandler.setDefaultConfigurable(vertexApiClient);
-        final VertexTaxCalculator calculator = new VertexTaxCalculator(vertexApiConfigurationHandler, dao, clock, osgiKillbillAPI);
-        testComputeItemsOverTime(calculator);
+        testComputeItemsOverTime(account, account2);
     }
 
     @Test(groups = "integration")
     public void testInvoiceItemAdjustmentOnNewInvoice() throws Exception {
-        final VertexApiConfigurationHandler vertexApiConfigurationHandler = new VertexApiConfigurationHandler(VertexActivator.PLUGIN_NAME, osgiKillbillAPI);
-        vertexApiConfigurationHandler.setDefaultConfigurable(vertexApiClient);
-        final VertexTaxCalculator calculator = new VertexTaxCalculator(vertexApiConfigurationHandler, dao, clock, osgiKillbillAPI);
-
+        //given
         final Invoice invoice = TestUtils.buildInvoice(account3);
         final InvoiceItem taxableItem1 = TestUtils.buildInvoiceItem(invoice, InvoiceItemType.EXTERNAL_CHARGE, new BigDecimal("100"), null);
         invoice.getInvoiceItems().add(taxableItem1);
         invoice.getInvoiceItems().add(TestUtils.buildInvoiceItem(invoice, InvoiceItemType.ITEM_ADJ, BigDecimal.ONE.negate(), taxableItem1.getId()));
 
-        // Compute the tax items
+        //when
         final List<InvoiceItem> initialTaxItems = calculator.compute(account3, invoice, false, pluginProperties, tenantContext);
-        Assert.assertEquals(dao.getSuccessfulResponses(invoice.getId(), tenantId).size(), 2);
 
-        // Check the created items
+        //then
+        Assert.assertEquals(dao.getSuccessfulResponses(invoice.getId(), tenantId).size(), 2);
         Assert.assertEquals(initialTaxItems.size(), 8);
     }
 
-    private void testComputeItemsOverTime(final VertexTaxCalculator calculator) throws Exception {
-        testComputeItemsOverTime(calculator, account);
-        testComputeItemsOverTime(calculator, account2);
+    @Test(groups = "integration")
+    public void testComputeWhenAddressHasSpecialCharacters() throws Exception {
+        //given
+        Account accountWithSpecialChars = TestUtils.buildAccount(Currency.USD, "Alexanderstraße 11", null, "berlin", "BE", "10178", "DE");
+        final Invoice invoice = TestUtils.buildInvoice(accountWithSpecialChars);
+        final InvoiceItem taxableItem = TestUtils.buildInvoiceItem(invoice, InvoiceItemType.EXTERNAL_CHARGE, new BigDecimal("100"), null);
+        invoice.getInvoiceItems().add(taxableItem);
+
+        //when
+        calculator.compute(accountWithSpecialChars, invoice, false, pluginProperties, tenantContext);
+
+        //then
+        Assert.assertEquals(dao.getSuccessfulResponses(invoice.getId(), tenantId).size(), 1);
     }
 
-    private void testComputeItemsOverTime(final VertexTaxCalculator calculator, final Account account) throws Exception {
+    private void testComputeItemsOverTime(final Account... accounts) throws Exception {
+        for (final Account account : accounts) {
+            testComputeItemsOverTime(account);
+        }
+    }
+
+    private void testComputeItemsOverTime(final Account account) throws Exception {
         final Invoice invoice = TestUtils.buildInvoice(account);
         // Avalara requires testing multiple descriptions and multiple tax codes for certification
         final InvoiceItem taxableItem1 = TestUtils.buildInvoiceItem(invoice, InvoiceItemType.EXTERNAL_CHARGE, new BigDecimal("100"), null);


### PR DESCRIPTION
Addresses https://packet.atlassian.net/browse/ENG-21930.

Needed as currently ISO-8859-1 is used by default in api client generated by apache-httpclient.
More info https://github.com/OpenAPITools/openapi-generator/issues/12797

Testing:

Tested by adding UTF-8 char in on of the addresses in VertexTaxCalculatorITest.
Confirmed locally issue is not reproduced after applying the fix.
mvn clean install -Pintegration-postgresql passed locally with hardcoded old token
Note: Integration tests are failing because of the issue with Vertex expired account: Service account expired