### PR TITLE
[CBS-23595] Fix malformed url for vertex due to trailing forward slash

### DIFF
--- a/src/main/java/org/killbill/billing/plugin/vertex/VertexApiClient.java
+++ b/src/main/java/org/killbill/billing/plugin/vertex/VertexApiClient.java
@@ -109,7 +109,7 @@ public class VertexApiClient {
         }
 
         ApiClient apiClient = new ApiClient();
-        apiClient.setBasePath(url + "/vertex-ws/");
+        apiClient.setBasePath(url + "/vertex-ws");
 
         OAuthClient oAuthClient = new OAuthClient();
         final String token = oAuthClient.getToken(url, clientId, clientSecret).getAccessToken();

--- a/src/test/java/org/killbill/billing/plugin/vertex/base/VertexRemoteTestBase.java
+++ b/src/test/java/org/killbill/billing/plugin/vertex/base/VertexRemoteTestBase.java
@@ -96,7 +96,7 @@ public abstract class VertexRemoteTestBase {
         OAuthClient oAuthClient = new OAuthClient();
 
         ApiClient apiClient = new ApiClient();
-        apiClient.setBasePath(getUrl() + "/vertex-ws/");
+        apiClient.setBasePath(getUrl() + "/vertex-ws");
         String token = oAuthClient.getToken(getUrl(), getClientId(), getClientSecret()).getAccessToken();
         apiClient.setAccessToken(token);
 


### PR DESCRIPTION
Vertex has started complaining about malformed url which has being working fine until now.
The issue is caused due to trailing `/`

See below screenshot
<img width="947" alt="Screen Shot 2024-04-09 at 3 41 16 PM" src="https://github.com/killbill/killbill-vertex-plugin/assets/95652809/f773be95-14bf-4a89-922b-370b7427ad00">
 
