### PR TITLE
Make taxRate part of item details for all tax items added to the invoice

### DIFF
--- a/src/main/java/org/killbill/billing/plugin/vertex/VertexTaxCalculator.java
+++ b/src/main/java/org/killbill/billing/plugin/vertex/VertexTaxCalculator.java
@@ -322,7 +322,7 @@ public class VertexTaxCalculator extends PluginTaxCalculator {
 
         if (taxRate == null) {
             logger.warn("The tax rate is not provided in the Vertex response for the tax item with ID: {} and calculated tax: {}", taxItem.getId(), calculatedTax);
-            taxRate = calculatedTax.divide(taxableItem.getAmount(), 5, RoundingMode.HALF_DOWN).doubleValue();
+            taxRate = calculatedTax.divide(taxableItem.getAmount(), 5, RoundingMode.FLOOR).doubleValue();
         }
 
         final String taxItemDetails = createTaxItemDetails(ImmutableMap.of("taxRate", taxRate));

--- a/src/main/java/org/killbill/billing/plugin/vertex/VertexTaxCalculator.java
+++ b/src/main/java/org/killbill/billing/plugin/vertex/VertexTaxCalculator.java
@@ -18,6 +18,7 @@
 package org.killbill.billing.plugin.vertex;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -315,8 +316,12 @@ public class VertexTaxCalculator extends PluginTaxCalculator {
 
     private InvoiceItem createTaxInvoiceItem(final InvoiceItem taxableItem, final UUID invoiceId, @Nullable final InvoiceItem adjustmentItem, final BigDecimal calculatedTax, @Nullable final String description, @Nullable Double taxRate) {
         final InvoiceItem taxItem = buildTaxItem(taxableItem, invoiceId, adjustmentItem, calculatedTax, description);
-        if (taxItem == null || taxRate == null) {
-            return taxItem;
+        if (taxItem == null) {
+            return null;
+        }
+
+        if (taxRate == null) {
+            taxRate = calculatedTax.divide(taxableItem.getAmount(), 5, RoundingMode.HALF_UP).doubleValue();
         }
 
         final String taxItemDetails = createTaxItemDetails(ImmutableMap.of("taxRate", taxRate));

--- a/src/main/java/org/killbill/billing/plugin/vertex/VertexTaxCalculator.java
+++ b/src/main/java/org/killbill/billing/plugin/vertex/VertexTaxCalculator.java
@@ -319,7 +319,7 @@ public class VertexTaxCalculator extends PluginTaxCalculator {
             return taxItem;
         }
 
-        final String taxItemDetails = createTaxItemDetails(taxRate);
+        final String taxItemDetails = createTaxItemDetails(ImmutableMap.of("taxRate", String.valueOf(taxRate)));
         if (taxItemDetails == null) {
             return taxItem;
         }
@@ -355,9 +355,9 @@ public class VertexTaxCalculator extends PluginTaxCalculator {
                                              .validate().build());
     }
 
-    private String createTaxItemDetails(@Nonnull final Double effectiveRate) {
+    private String createTaxItemDetails(@Nonnull final Map<String, String> taxItemDetails) {
         try {
-            return objectMapper.writeValueAsString(ImmutableMap.of("taxRate", String.valueOf(effectiveRate)));
+            return objectMapper.writeValueAsString(taxItemDetails);
         } catch (JsonProcessingException ignored) {
             return null;
         }

--- a/src/main/java/org/killbill/billing/plugin/vertex/VertexTaxCalculator.java
+++ b/src/main/java/org/killbill/billing/plugin/vertex/VertexTaxCalculator.java
@@ -321,8 +321,8 @@ public class VertexTaxCalculator extends PluginTaxCalculator {
         }
 
         if (taxRate == null) {
-            logger.info("The tax rate is not provided in the Vertex response for the tax item with ID: {} and calculated tax: {}", taxItem.getId(), calculatedTax);
-            taxRate = calculatedTax.divide(taxableItem.getAmount(), 5, RoundingMode.HALF_UP).doubleValue();
+            logger.warn("The tax rate is not provided in the Vertex response for the tax item with ID: {} and calculated tax: {}", taxItem.getId(), calculatedTax);
+            taxRate = calculatedTax.divide(taxableItem.getAmount(), 5, RoundingMode.HALF_DOWN).doubleValue();
         }
 
         final String taxItemDetails = createTaxItemDetails(ImmutableMap.of("taxRate", taxRate));

--- a/src/main/java/org/killbill/billing/plugin/vertex/VertexTaxCalculator.java
+++ b/src/main/java/org/killbill/billing/plugin/vertex/VertexTaxCalculator.java
@@ -321,6 +321,7 @@ public class VertexTaxCalculator extends PluginTaxCalculator {
         }
 
         if (taxRate == null) {
+            logger.info("The tax rate is not provided in the Vertex response for the tax item with ID: {} and calculated tax: {}", taxItem.getId(), calculatedTax);
             taxRate = calculatedTax.divide(taxableItem.getAmount(), 5, RoundingMode.HALF_UP).doubleValue();
         }
 
@@ -363,7 +364,8 @@ public class VertexTaxCalculator extends PluginTaxCalculator {
     private String createTaxItemDetails(@Nonnull final Map<String, Object> taxItemDetails) {
         try {
             return objectMapper.writeValueAsString(taxItemDetails);
-        } catch (JsonProcessingException ignored) {
+        } catch (JsonProcessingException exception) {
+            logger.error("Couldn't serialize the tax item details: {}", taxItemDetails, exception);
             return null;
         }
     }

--- a/src/main/java/org/killbill/billing/plugin/vertex/VertexTaxCalculator.java
+++ b/src/main/java/org/killbill/billing/plugin/vertex/VertexTaxCalculator.java
@@ -319,7 +319,7 @@ public class VertexTaxCalculator extends PluginTaxCalculator {
             return taxItem;
         }
 
-        final String taxItemDetails = createTaxItemDetails(ImmutableMap.of("taxRate", String.valueOf(taxRate)));
+        final String taxItemDetails = createTaxItemDetails(ImmutableMap.of("taxRate", taxRate));
         if (taxItemDetails == null) {
             return taxItem;
         }
@@ -355,7 +355,7 @@ public class VertexTaxCalculator extends PluginTaxCalculator {
                                              .validate().build());
     }
 
-    private String createTaxItemDetails(@Nonnull final Map<String, String> taxItemDetails) {
+    private String createTaxItemDetails(@Nonnull final Map<String, Object> taxItemDetails) {
         try {
             return objectMapper.writeValueAsString(taxItemDetails);
         } catch (JsonProcessingException ignored) {

--- a/src/test/java/org/killbill/billing/plugin/vertex/VertexTaxCalculatorTest.java
+++ b/src/test/java/org/killbill/billing/plugin/vertex/VertexTaxCalculatorTest.java
@@ -142,7 +142,6 @@ public class VertexTaxCalculatorTest {
 
         given(responseLineItem.getLineItemId()).willReturn(TAX_ITEM_ID.toString());
         given(responseLineItem.getTotalTax()).willReturn(MOCK_TAX_AMOUNT_1_01);
-        given(responseLineItem.getTotalTax()).willReturn(MOCK_TAX_AMOUNT_1_01);
 
         given(vertexApiClient.calculateTaxes(any(SaleRequestType.class))).willReturn(taxResponse);
         given(taxResponse.getData()).willReturn(apiResponseData);

--- a/src/test/java/org/killbill/billing/plugin/vertex/VertexTaxCalculatorTest.java
+++ b/src/test/java/org/killbill/billing/plugin/vertex/VertexTaxCalculatorTest.java
@@ -245,7 +245,7 @@ public class VertexTaxCalculatorTest {
 
         //then it persisted in item details invoice item field
         List<InvoiceItem> result = vertexTaxCalculator.compute(account, invoice, true, Collections.emptyList(), tenantContext);
-        assertEquals("{\"taxRate\":\"0.09975\"}", result.get(0).getItemDetails());
+        assertEquals("{\"taxRate\":0.09975}", result.get(0).getItemDetails());
         checkTaxItemFields(result.get(0));
 
         //given effective rate is not present
@@ -308,7 +308,7 @@ public class VertexTaxCalculatorTest {
         //then it persisted in item details invoice item field
         List<InvoiceItem> result = vertexTaxCalculator.compute(account, invoice, true, Collections.emptyList(), tenantContext);
         assertEquals(1, result.size());
-        assertEquals("{\"taxRate\":\"0.0\"}", result.get(0).getItemDetails());
+        assertEquals("{\"taxRate\":0.0}", result.get(0).getItemDetails());
         checkTaxItemFields(result.get(0));
     }
 

--- a/src/test/java/org/killbill/billing/plugin/vertex/VertexTaxCalculatorTest.java
+++ b/src/test/java/org/killbill/billing/plugin/vertex/VertexTaxCalculatorTest.java
@@ -58,6 +58,7 @@ import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertNull;
 
 public class VertexTaxCalculatorTest {
 
@@ -157,7 +158,6 @@ public class VertexTaxCalculatorTest {
         //given
         given(taxResponse.getData()).willReturn(apiResponseData);
         given(invoice.getInvoiceItems()).willReturn(Collections.singletonList(taxableInvoiceItem));
-
         final boolean isDryRun = false;
 
         //when
@@ -229,6 +229,40 @@ public class VertexTaxCalculatorTest {
         given(responseLineItem.getTaxes()).willReturn(Collections.singletonList(taxesType));
         result = vertexTaxCalculator.compute(account, invoice, isDryRun, Collections.emptyList(), tenantContext);
         assertEquals("CA STATE TAX", result.get(0).getDescription());
+    }
+
+    @Test(groups = "fast")
+    public void testTaxEffectiveRate() throws Exception {
+        //given
+        given(invoice.getInvoiceItems()).willReturn(Collections.singletonList(taxableInvoiceItem));
+        given(taxResponse.getData()).willReturn(apiResponseData);
+        final TaxesType taxesType = new TaxesType();
+        taxesType.setCalculatedTax(MOCK_TAX_AMOUNT_1_01);
+        given(responseLineItem.getTaxes()).willReturn(Collections.singletonList(taxesType));
+
+        //given tax effective rate is present
+        taxesType.setEffectiveRate(0.09975d);
+
+        //then it persisted in item details invoice item field
+        List<InvoiceItem> result = vertexTaxCalculator.compute(account, invoice, true, Collections.emptyList(), tenantContext);
+        assertEquals("{\"taxRate\":\"0.09975\"}", result.get(0).getItemDetails());
+        checkTaxItemFields(result.get(0));
+
+        //given effective rate is not present
+        taxesType.setEffectiveRate(null);
+
+        //then no item details persisted
+        result = vertexTaxCalculator.compute(account, invoice, true, Collections.emptyList(), tenantContext);
+        assertNull(result.get(0).getItemDetails());
+        checkTaxItemFields(result.get(0));
+    }
+
+    private void checkTaxItemFields(final InvoiceItem taxItem) {
+        assertEquals(InvoiceItemType.TAX, taxItem.getInvoiceItemType());
+        assertEquals("Tax", taxItem.getDescription());
+        assertEquals(INVOICE_ID, taxItem.getInvoiceId());
+        assertEquals(INVOICE_DATE, taxItem.getStartDate());
+        assertEquals(INVOICE_DATE.plusMonths(1), taxItem.getEndDate());
     }
 
     @Test(groups = "fast", expectedExceptions = {IllegalStateException.class})

--- a/src/test/java/org/killbill/billing/plugin/vertex/VertexTaxCalculatorTest.java
+++ b/src/test/java/org/killbill/billing/plugin/vertex/VertexTaxCalculatorTest.java
@@ -257,6 +257,61 @@ public class VertexTaxCalculatorTest {
         checkTaxItemFields(result.get(0));
     }
 
+    @Test(groups = "fast")
+    public void testComputeWhenTaxEffectiveRateIsNotPresented() throws Exception {
+        //given
+        given(invoice.getInvoiceItems()).willReturn(Collections.singletonList(taxableInvoiceItem));
+        given(taxResponse.getData()).willReturn(apiResponseData);
+        final TaxesType taxesType = new TaxesType();
+        taxesType.setCalculatedTax(MOCK_TAX_AMOUNT_1_01);
+        given(responseLineItem.getTaxes()).willReturn(Collections.singletonList(taxesType));
+
+        //given tax effective rate is not present
+        taxesType.setEffectiveRate(null);
+
+        //then it persisted in item details invoice item field
+        List<InvoiceItem> result = vertexTaxCalculator.compute(account, invoice, true, Collections.emptyList(), tenantContext);
+        assertEquals(1, result.size());
+        assertNull(result.get(0).getItemDetails());
+        checkTaxItemFields(result.get(0));
+    }
+
+    @Test(groups = "fast")
+    public void testComputeWhenEffectiveTaxRateZero() throws Exception {
+        //given
+        given(invoice.getInvoiceItems()).willReturn(Collections.singletonList(taxableInvoiceItem));
+        given(taxResponse.getData()).willReturn(apiResponseData);
+        final TaxesType taxesType = new TaxesType();
+        taxesType.setCalculatedTax(0d);
+        given(responseLineItem.getTaxes()).willReturn(Collections.singletonList(taxesType));
+
+        //given tax effective rate is present
+        taxesType.setEffectiveRate(0d);
+
+        //then it persisted in item details invoice item field
+        List<InvoiceItem> result = vertexTaxCalculator.compute(account, invoice, true, Collections.emptyList(), tenantContext);
+        assertEquals(0, result.size());
+    }
+
+    @Test(groups = "fast")
+    public void testComputeWhenEffectiveTaxRateZeroButAmountIsNot() throws Exception {
+        //given
+        given(invoice.getInvoiceItems()).willReturn(Collections.singletonList(taxableInvoiceItem));
+        given(taxResponse.getData()).willReturn(apiResponseData);
+        final TaxesType taxesType = new TaxesType();
+        taxesType.setCalculatedTax(MOCK_TAX_AMOUNT_1_01);
+        given(responseLineItem.getTaxes()).willReturn(Collections.singletonList(taxesType));
+
+        //given tax effective rate is present
+        taxesType.setEffectiveRate(0d);
+
+        //then it persisted in item details invoice item field
+        List<InvoiceItem> result = vertexTaxCalculator.compute(account, invoice, true, Collections.emptyList(), tenantContext);
+        assertEquals(1, result.size());
+        assertEquals("{\"taxRate\":\"0.0\"}", result.get(0).getItemDetails());
+        checkTaxItemFields(result.get(0));
+    }
+
     private void checkTaxItemFields(final InvoiceItem taxItem) {
         assertEquals(InvoiceItemType.TAX, taxItem.getInvoiceItemType());
         assertEquals("Tax", taxItem.getDescription());


### PR DESCRIPTION
Using Invoice's `itemDetails` field to preserve for TAX items effective tax rate obtained from vertex as json object in the format (example):
`{"taxRate":0.09975}`

This field can be used for more information if needed in the future